### PR TITLE
Check if setup is run before executing commands

### DIFF
--- a/app/Commands/BaseCommand.php
+++ b/app/Commands/BaseCommand.php
@@ -53,10 +53,12 @@ abstract class BaseCommand extends Command
     /**
      * Execute the console command.
      *
-     * @param  \Symfony\Component\Console\Input\InputInterface   $input
-     * @param  \Symfony\Component\Console\Output\OutputInterface $output
-     * @return mixed
+     * @param \Symfony\Component\Console\Input\InputInterface   $input
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
+     *
      * @throws PorterNotSetUp
+     *
+     * @return mixed
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
@@ -65,7 +67,6 @@ abstract class BaseCommand extends Command
         return parent::execute($input, $output);
     }
 
-
     /**
      * Ensure that Porter has been set up if necessary before continuing.
      *
@@ -73,7 +74,7 @@ abstract class BaseCommand extends Command
      */
     private function checkPorterIsSetUp()
     {
-        if ($this->porterMustBeSetUp && ! $this->porterLibrary->alreadySetUp()) {
+        if ($this->porterMustBeSetUp && !$this->porterLibrary->alreadySetUp()) {
             throw new PorterNotSetUp('Porter must be set up to run this command. Run \'porter begin\' first.');
         }
     }

--- a/app/Commands/BaseCommand.php
+++ b/app/Commands/BaseCommand.php
@@ -2,12 +2,15 @@
 
 namespace App\Commands;
 
+use App\Exceptions\PorterNotSetUp;
 use App\Porter;
 use App\PorterLibrary;
 use App\Support\Console\Cli;
 use App\Support\Console\DockerCompose\CliCommandFactory;
 use LaravelZero\Framework\Commands\Command;
 use NunoMaduro\LaravelConsoleMenu\Menu;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * @method Menu menu(string $title, array $options)
@@ -26,17 +29,52 @@ abstract class BaseCommand extends Command
     /** @var PorterLibrary */
     protected $porterLibrary;
 
+    /**
+     * If true, the command will not run unless the setup process has been run.
+     *
+     * @var bool
+     */
+    protected $porterMustBeSetUp = true;
+
     public function __construct(
         Cli $cli,
         CliCommandFactory $dockerCompose,
         Porter $porter,
-        PorterLibrary $porterLibrary)
-    {
+        PorterLibrary $porterLibrary
+    ) {
         parent::__construct();
 
         $this->cli = $cli;
         $this->dockerCompose = $dockerCompose;
         $this->porter = $porter;
         $this->porterLibrary = $porterLibrary;
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @param  \Symfony\Component\Console\Input\InputInterface   $input
+     * @param  \Symfony\Component\Console\Output\OutputInterface $output
+     * @return mixed
+     * @throws PorterNotSetUp
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->checkPorterIsSetUp();
+
+        return parent::execute($input, $output);
+    }
+
+
+    /**
+     * Ensure that Porter has been set up if necessary before continuing.
+     *
+     * @throws PorterNotSetUp
+     */
+    private function checkPorterIsSetUp()
+    {
+        if ($this->porterMustBeSetUp && ! $this->porterLibrary->alreadySetUp()) {
+            throw new PorterNotSetUp('Porter must be set up to run this command. Run \'porter begin\' first.');
+        }
     }
 }

--- a/app/Commands/Begin.php
+++ b/app/Commands/Begin.php
@@ -7,6 +7,13 @@ use App\Exceptions\PorterSetupFailed;
 class Begin extends BaseCommand
 {
     /**
+     * The begin command may be run at any time, since it's needed to perform setup.
+     *
+     * @var bool
+     */
+    protected $porterMustBeSetUp = false;
+
+    /**
      * The signature of the command.
      *
      * @var string

--- a/app/Exceptions/PorterException.php
+++ b/app/Exceptions/PorterException.php
@@ -6,5 +6,4 @@ use Exception;
 
 class PorterException extends Exception
 {
-
 }

--- a/app/Exceptions/PorterException.php
+++ b/app/Exceptions/PorterException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Exceptions;
+
+use Exception;
+
+class PorterException extends Exception
+{
+
+}

--- a/app/Exceptions/PorterNotSetUp.php
+++ b/app/Exceptions/PorterNotSetUp.php
@@ -4,5 +4,4 @@ namespace App\Exceptions;
 
 class PorterNotSetUp extends PorterException
 {
-
 }

--- a/app/Exceptions/PorterNotSetUp.php
+++ b/app/Exceptions/PorterNotSetUp.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace App\Exceptions;
+
+class PorterNotSetUp extends PorterException
+{
+
+}

--- a/app/Exceptions/PorterSetupFailed.php
+++ b/app/Exceptions/PorterSetupFailed.php
@@ -4,5 +4,4 @@ namespace App\Exceptions;
 
 class PorterSetupFailed extends PorterException
 {
-    
 }

--- a/app/Exceptions/PorterSetupFailed.php
+++ b/app/Exceptions/PorterSetupFailed.php
@@ -2,9 +2,7 @@
 
 namespace App\Exceptions;
 
-use Exception;
-
-class PorterSetupFailed extends Exception
+class PorterSetupFailed extends PorterException
 {
-    //
+    
 }

--- a/app/PorterLibrary.php
+++ b/app/PorterLibrary.php
@@ -11,13 +11,25 @@ use Illuminate\Support\Facades\Artisan;
 
 class PorterLibrary
 {
-    /** @var string */
+    /**
+     * The path of the Porter library directory (e.g. ~/.porter on Mac).
+     *
+     * @var string
+     */
     protected $path;
 
-    /** @var Filesystem */
+    /**
+     * The system's filesystem.
+     *
+     * @var Filesystem
+     */
     protected $files;
 
-    /** @var \App\Support\FilePublisher * */
+    /**
+     * The file publisher.
+     *
+     * @var \App\Support\FilePublisher
+     */
     protected $filePublisher;
 
     protected $shouldMigrateAndSeedDatabase = true;

--- a/tests/Unit/Commands/CommandTest.php
+++ b/tests/Unit/Commands/CommandTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Tests\Unit\Commands;
+
+use App\Commands\BaseCommand;
+use App\Exceptions\PorterNotSetUp;
+use App\Porter;
+use App\PorterLibrary;
+use App\Support\Console\Cli;
+use App\Support\Console\DockerCompose\CliCommandFactory;
+use Mockery;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\ConsoleOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+use Tests\BaseTestCase;
+
+
+class CommandTest extends BaseTestCase
+{
+    /** @test */
+    public function it_checks_if_porter_has_been_set_up()
+    {
+        $porterLibrary = Mockery::mock(PorterLibrary::class);
+        $porterLibrary->shouldReceive('alreadySetUp')->andReturn(false);
+
+        $this->expectException(PorterNotSetUp::class);
+
+        $command = new SomeCommand(
+            Mockery::spy(Cli::class),
+            Mockery::spy(CliCommandFactory::class),
+            Mockery::spy(Porter::class),
+            $porterLibrary
+        );
+
+        $command->run(Mockery::spy(InputInterface::class), new ConsoleOutput);
+    }
+}
+
+class SomeCommand extends BaseCommand
+{
+}

--- a/tests/Unit/Commands/CommandTest.php
+++ b/tests/Unit/Commands/CommandTest.php
@@ -13,7 +13,6 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Tests\BaseTestCase;
 
-
 class CommandTest extends BaseTestCase
 {
     /** @test */
@@ -31,7 +30,7 @@ class CommandTest extends BaseTestCase
             $porterLibrary
         );
 
-        $command->run(Mockery::spy(InputInterface::class), new ConsoleOutput);
+        $command->run(Mockery::spy(InputInterface::class), new ConsoleOutput());
     }
 
     /** @test */
@@ -43,10 +42,10 @@ class CommandTest extends BaseTestCase
             Mockery::spy(Porter::class),
             Mockery::spy(PorterLibrary::class)
         );
-        $command->setLaravel(new \Illuminate\Container\Container);
+        $command->setLaravel(new \Illuminate\Container\Container());
 
         $input = Mockery::spy(InputInterface::class);
-        $command->run($input, new ConsoleOutput);
+        $command->run($input, new ConsoleOutput());
 
         // Check that the handle() method is executed
         $input->shouldHaveReceived('getOptions');


### PR DESCRIPTION
All commands except `porter begin` will fail unless the Porter library detects that the setup has been run.

Perhaps worth being more thorough with the `alreadySetUp()` method, check the database for example.