### PR TITLE
Changes to enable Laravel Mix nom run hot

### DIFF
--- a/app/Commands/Dns/SetHost.php
+++ b/app/Commands/Dns/SetHost.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Commands\Dns;
+
+use App\Commands\BaseCommand;
+use App\Support\Dnsmasq\Config;
+use App\Support\Mechanics\Mechanic;
+
+class SetHost extends BaseCommand
+{
+    /**
+     * The signature of the command.
+     *
+     * @var string
+     */
+    protected $signature = 'dns:set-host {--restore}';
+
+    /**
+     * The description of the command.
+     *
+     * @var string
+     */
+    protected $description = 'Set the host based on the OS';
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle(): void
+    {
+        $mechanic = app(Mechanic::class);
+
+        if ($this->option('restore')) {
+            $mechanic->restoreNetworking();
+            app(Config::class)->updateIp('127.0.0.1');
+            return;
+        }
+
+        $mechanic->setupNetworking();
+        app(Config::class)->updateIp($mechanic->getHostAddress());
+    }
+}

--- a/app/Commands/Dns/SetHost.php
+++ b/app/Commands/Dns/SetHost.php
@@ -34,6 +34,7 @@ class SetHost extends BaseCommand
         if ($this->option('restore')) {
             $mechanic->restoreNetworking();
             app(Config::class)->updateIp('127.0.0.1');
+
             return;
         }
 

--- a/app/Support/Console/DockerCompose/CliCommandFactory.php
+++ b/app/Support/Console/DockerCompose/CliCommandFactory.php
@@ -53,6 +53,6 @@ class CliCommandFactory
         $site = Site::resolveFromPathOrCurrentWorkingDirectory();
         $workingDir = $site ? '-w /srv/app/'.$site->name : '';
 
-        return new CliCommand($this->cli, "run {$workingDir} --rm {$container}");
+        return new CliCommand($this->cli, "run {$workingDir} --rm --service-ports {$container}");
     }
 }

--- a/app/Support/Dnsmasq/Config.php
+++ b/app/Support/Dnsmasq/Config.php
@@ -37,7 +37,7 @@ class Config
 
     protected function getPath()
     {
-        return $this->porterLibrary->configPath() . '/dnsmasq/dnsmasq.conf';
+        return $this->porterLibrary->configPath().'/dnsmasq/dnsmasq.conf';
     }
 
     protected function getConfig()

--- a/app/Support/Dnsmasq/Config.php
+++ b/app/Support/Dnsmasq/Config.php
@@ -3,6 +3,7 @@
 namespace App\Support\Dnsmasq;
 
 use App\PorterLibrary;
+use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use Illuminate\Filesystem\Filesystem;
 
 class Config
@@ -21,10 +22,35 @@ class Config
 
     public function updateDomain($from, $to)
     {
-        $filePath = $this->porterLibrary->configPath().'/dnsmasq/dnsmasq.conf';
+        $newConfig = preg_replace("/\/.{$from}\//", "/.{$to}/", $this->getConfig());
 
-        $newConfig = preg_replace("/\/.{$from}\//", "/.{$to}/", file_get_contents($filePath));
+        $this->putConfig($newConfig);
+    }
 
-        $this->files->put($filePath, $newConfig);
+    public function updateIp($to)
+    {
+        $pattern = "/\/\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/";
+        $newConfig = preg_replace($pattern, "/{$to}", $this->getConfig());
+
+        $this->putConfig($newConfig);
+    }
+
+    protected function getPath()
+    {
+        return $this->porterLibrary->configPath() . '/dnsmasq/dnsmasq.conf';
+    }
+
+    protected function getConfig()
+    {
+        try {
+            return $this->files->get($this->getPath());
+        } catch (FileNotFoundException $e) {
+            return '';
+        }
+    }
+
+    protected function putConfig($content)
+    {
+        $this->files->put($this->getPath(), $content);
     }
 }

--- a/app/Support/Mechanics/MacOs.php
+++ b/app/Support/Mechanics/MacOs.php
@@ -61,7 +61,7 @@ class MacOs extends Untrained
     }
 
     /**
-     * Set up networking for Mac
+     * Set up networking for Mac.
      *
      * Add a loopback alias to 10.200.10.1. This is then used as the IP for DNS resolution, otherwise
      * we get weird results when trying to access services hosted in docker (since they resolve
@@ -79,7 +79,7 @@ class MacOs extends Untrained
     }
 
     /**
-     * Restore networking on Mac
+     * Restore networking on Mac.
      *
      * @return void
      */
@@ -93,7 +93,7 @@ class MacOs extends Untrained
     }
 
     /**
-     * Return the host IP address in use
+     * Return the host IP address in use.
      *
      * @return string
      */

--- a/app/Support/Mechanics/MacOs.php
+++ b/app/Support/Mechanics/MacOs.php
@@ -4,6 +4,9 @@ namespace App\Support\Mechanics;
 
 class MacOs extends Untrained
 {
+    /** @var string $hostAddress Address for Host */
+    protected $hostAddress = '10.200.10.1';
+
     /**
      * Trust the given root certificate file in the Keychain.
      *
@@ -55,5 +58,47 @@ class MacOs extends Untrained
     {
         $this->consoleWriter->info('Flushing DNS. Requires sudo permissions.');
         $this->cli->passthru('sudo killall -HUP mDNSResponder');
+    }
+
+    /**
+     * Set up networking for Mac
+     *
+     * Add a loopback alias to 10.200.10.1. This is then used as the IP for DNS resolution, otherwise
+     * we get weird results when trying to access services hosted in docker (since they resolve
+     * 127.0.0.1 to the requesting container).
+     *
+     * @return void
+     */
+    public function setupNetworking()
+    {
+        $this->consoleWriter->info("Adding loopback alias to {$this->hostAddress}/24. Please provide your sudo password.");
+
+        $command = "sudo ifconfig lo0 alias {$this->hostAddress}/24";
+
+        $this->cli->passthru($command);
+    }
+
+    /**
+     * Restore networking on Mac
+     *
+     * @return void
+     */
+    public function restoreNetworking()
+    {
+        $this->consoleWriter->info("Removing loopback alias to {$this->hostAddress}. Please provide your sudo password.");
+
+        $command = "sudo ifconfig lo0 -alias {$this->hostAddress}";
+
+        $this->cli->passthru($command);
+    }
+
+    /**
+     * Return the host IP address in use
+     *
+     * @return string
+     */
+    public function getHostAddress()
+    {
+        return $this->hostAddress;
     }
 }

--- a/app/Support/Mechanics/Mechanic.php
+++ b/app/Support/Mechanics/Mechanic.php
@@ -35,4 +35,23 @@ interface Mechanic
      * @return void
      */
     public function flushDns();
+
+    /**
+     * Setup networking for Porter
+     *
+     * @return void
+     */
+    public function setupNetworking();
+
+    /**
+     * Restore networking
+     *
+     * @return void
+     */
+    public function restoreNetworking();
+
+    /**
+     * Get Host IP address
+     */
+    public function getHostAddress();
 }

--- a/app/Support/Mechanics/Mechanic.php
+++ b/app/Support/Mechanics/Mechanic.php
@@ -37,21 +37,21 @@ interface Mechanic
     public function flushDns();
 
     /**
-     * Setup networking for Porter
+     * Setup networking for Porter.
      *
      * @return void
      */
     public function setupNetworking();
 
     /**
-     * Restore networking
+     * Restore networking.
      *
      * @return void
      */
     public function restoreNetworking();
 
     /**
-     * Get Host IP address
+     * Get Host IP address.
      */
     public function getHostAddress();
 }

--- a/app/Support/Mechanics/Untrained.php
+++ b/app/Support/Mechanics/Untrained.php
@@ -90,7 +90,7 @@ class Untrained implements Mechanic
     }
 
     /**
-     * Setup networking for Porter
+     * Setup networking for Porter.
      *
      * @return void
      */
@@ -100,7 +100,7 @@ class Untrained implements Mechanic
     }
 
     /**
-     * Restore networking for Porter
+     * Restore networking for Porter.
      *
      * @return void
      */
@@ -110,7 +110,7 @@ class Untrained implements Mechanic
     }
 
     /**
-     * Get Host IP for Porter
+     * Get Host IP for Porter.
      *
      * @return string
      */

--- a/app/Support/Mechanics/Untrained.php
+++ b/app/Support/Mechanics/Untrained.php
@@ -17,6 +17,9 @@ class Untrained implements Mechanic
     /** @var ServerBag */
     protected $serverBag;
 
+    /** @var string $hostAddress Address for Host */
+    protected $hostAddress = '127.0.0.1';
+
     /**
      * Untrained constructor.
      *
@@ -84,5 +87,35 @@ class Untrained implements Mechanic
     {
         $this->consoleWriter->info("I haven't been trained to {$activity} on this system.");
         $this->consoleWriter->info('You are welcome to train me and submit a PR.');
+    }
+
+    /**
+     * Setup networking for Porter
+     *
+     * @return void
+     */
+    public function setupNetworking()
+    {
+        $this->iAmNotTrainedTo('set up special networking for Porter');
+    }
+
+    /**
+     * Restore networking for Porter
+     *
+     * @return void
+     */
+    public function restoreNetworking()
+    {
+        $this->iAmNotTrainedTo('restore special networking for Porter');
+    }
+
+    /**
+     * Get Host IP for Porter
+     *
+     * @return string
+     */
+    public function getHostAddress()
+    {
+        return $this->hostAddress;
     }
 }

--- a/resources/image_sets/konsulting/porter-ubuntu/docker_compose/node.blade.php
+++ b/resources/image_sets/konsulting/porter-ubuntu/docker_compose/node.blade.php
@@ -5,8 +5,12 @@
     image: {{ $imageSet->firstByServiceName('node')->getName() }}
     user: node
     volumes:
-      - {{ $home }}:/srv/app:delegated
+      - {{ $home }}:/srv/app
       - {{ $libraryPath }}/config/user/ssh:/root/.ssh
       - {{ $libraryPath }}/config/node/bash_history:/home/node/.bash_history
     networks:
       - porter
+    ports:
+      - 3000:3000
+      - 3001:3001
+      - 8080:8080

--- a/tests/Unit/Support/DnsMasq/ConfigTest.php
+++ b/tests/Unit/Support/DnsMasq/ConfigTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\Unit\Support\DnsMasq;
+
+use App\PorterLibrary;
+use App\Support\Dnsmasq\Config;
+use Illuminate\Filesystem\Filesystem;
+use Mockery;
+use Tests\BaseTestCase;
+
+class ConfigTest extends BaseTestCase
+{
+    /** @test */
+    public function it_updates_the_ip_address()
+    {
+        $files = Mockery::mock(Filesystem::class);
+        $porterLibrary = Mockery::mock(PorterLibrary::class);
+
+        $config = new Config($files, $porterLibrary);
+
+        $files->shouldReceive('get')->once()->andReturn('/0.0.0.0');
+        $files->shouldReceive('put')->with('/dnsmasq/dnsmasq.conf', '/1.1.1.1')->once();
+
+        $porterLibrary->shouldReceive('configPath')->twice()->andReturn('');
+
+        $config->updateIp('1.1.1.1');
+    }
+
+    /** @test */
+    public function it_updates_the_domain()
+    {
+        $files = Mockery::mock(Filesystem::class);
+        $porterLibrary = Mockery::mock(PorterLibrary::class);
+
+        $config = new Config($files, $porterLibrary);
+
+        $files->shouldReceive('get')->once()->andReturn('/.dev/0.0.0.0');
+        $files->shouldReceive('put')->with('/dnsmasq/dnsmasq.conf', '/.test/0.0.0.0')->once();
+
+        $porterLibrary->shouldReceive('configPath')->twice()->andReturn('');
+
+        $config->updateDomain('dev', 'test');
+    }
+}

--- a/tests/Unit/Support/Mechanics/MacOsTest.php
+++ b/tests/Unit/Support/Mechanics/MacOsTest.php
@@ -28,4 +28,34 @@ class MacOsTest extends MechanicTestCase
 
         $this->getMechanic()->flushDns();
     }
+
+    /** @test */
+    public function it_can_setup_networking()
+    {
+        $this->consoleWriter->shouldReceive('info')->once();
+
+        $this->cli->shouldReceive('passthru')
+            ->with('sudo ifconfig lo0 alias 10.200.10.1/24')
+            ->once();
+
+        $this->getMechanic()->setupNetworking();
+    }
+
+    /** @test */
+    public function it_can_restore_networking()
+    {
+        $this->consoleWriter->shouldReceive('info')->once();
+
+        $this->cli->shouldReceive('passthru')
+            ->with('sudo ifconfig lo0 -alias 10.200.10.1')
+            ->once();
+
+        $this->getMechanic()->restoreNetworking();
+    }
+
+    /** @test */
+    public function it_returns_the_host_address()
+    {
+        $this->assertEquals('10.200.10.1', $this->getMechanic()->getHostAddress());
+    }
 }

--- a/tests/Unit/Support/Mechanics/UntrainedTest.php
+++ b/tests/Unit/Support/Mechanics/UntrainedTest.php
@@ -26,6 +26,14 @@ class UntrainedTest extends MechanicTestCase
             ['trustCertificate', ['']],
             ['getUserHomePath'],
             ['flushDns'],
+            ['setupNetworking'],
+            ['restoreNetworking'],
         ];
+    }
+
+    /** @test */
+    public function it_returns_the_host_address()
+    {
+        $this->assertEquals('127.0.0.1', $this->getMechanic()->getHostAddress());
     }
 }


### PR DESCRIPTION
Changes to allow hot reloading to work with the Node container. 

On Mac, add the ability to specify an alias address for the loopback, which we then use for resolving DNS entries to the Porter domain. This means that DNS lookups from within containers resolve to the Host and not to the container which initiated the lookup. (A side effect of this that it also fixes Curl/similar from dev sites to other dev sites in Porter).

Document new commands, some explanation and required changes to Mix config to use hot reloading with the node container.