### PR TITLE
Add default servers for NGiNX

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Contributions are welcome.  We are a small company, so please be patient if your
     source .bash_profile
     ```
  
- - Set up routing... you have some options.
+ - Set up DNS resolution... you have some options.
    
    1. Use the DNS container shipped with Porter.  Update your machine's network DNS settings to point to 127.0.0.1 before other name servers. The container will resolve the domain for Porter. You will need to turn off locally any installed DNSmasq since the DNS container opens to port 53 on localhost. (e.g. `brew services stop dnsmasq`)
    
@@ -53,7 +53,9 @@ Contributions are welcome.  We are a small company, so please be patient if your
 
  - Porter binds to ports 80 and 443, so you need to turn Valet off (`valet stop`) or any other services that are bound to them before using it.
  
- - In your terminal `cd` to the directory where your sites are located, and run `porter begin`
+ - In your terminal `cd` to the directory where your sites are located, and run `porter begin`. 
+ 
+    This command will ask for your home directory (the root of your sites) and will generate a CA Certificate (and ask your permission to trust it on Mac).
  
  - Finally run `porter start`
  
@@ -84,7 +86,7 @@ We have deliberately chosen not to make this automatic, nor permanent to avoid d
 
 ## Commands
 
- - `porter begin {--home?} {--force?}` - Migrate and seed the sqlite database, and publish config files to `~/.porter/config`. It will set Porter home to the working directory when you run the command (or you can specify with the `--home` option).  It will also download the required docker images.
+ - `porter begin {--home?} {--force?}` - Migrate and seed the sqlite database, and publish config files to `~/.porter/config`. It will set Porter home to the working directory when you run the command (or you can specify with the `--home` option).  It will also create a CA certificate (asking you to trust it on a Mac) and it will download the required docker images.
  - `porter start`
  - `porter status` - show the status of containers
  - `porter stop`

--- a/app/Commands/MakeFiles.php
+++ b/app/Commands/MakeFiles.php
@@ -3,6 +3,7 @@
 namespace App\Commands;
 
 use App\Models\Site;
+use App\Support\Ssl\CertificateBuilder;
 
 class MakeFiles extends BaseCommand
 {
@@ -38,6 +39,10 @@ class MakeFiles extends BaseCommand
         foreach (Site::all() as $site) {
             $site->buildFiles();
         }
+
+        // The porter_default certificate is used for serving error pages
+        // when a domain has not been set up in Porter
+        app(CertificateBuilder::class)->build('porter_default');
 
         if ($wasUp) {
             $this->call('start');

--- a/app/Commands/Site/RenewCertificates.php
+++ b/app/Commands/Site/RenewCertificates.php
@@ -29,7 +29,13 @@ class RenewCertificates extends BaseCommand
      */
     public function handle(): void
     {
-        app(CertificateBuilder::class)->clearCertificates((bool) $this->option('clear-ca'));
+        /** @var CertificateBuilder $builder */
+        $builder = app(CertificateBuilder::class);
+        $builder->clearCertificates((bool) $this->option('clear-ca'));
+
+        // The porter_default certificate is used for serving error pages
+        // when a domain has not been set up in Porter
+        $builder->build('porter_default');
 
         foreach (Site::where('secure', true)->get() as $site) {
             $site->buildCertificate();

--- a/resources/stubs/config/nginx/nginx.conf
+++ b/resources/stubs/config/nginx/nginx.conf
@@ -41,5 +41,30 @@ http {
         text/x-component
     ;
 
+    server {
+        listen 80 default_server;
+        server_name _;
+
+        default_type text/plain;
+
+        location / {
+            return 404 "Domain not set up in Porter";
+        }
+    }
+
+    server {
+        listen 443 ssl http2 default_server;
+        server_name _;
+
+        ssl_certificate /etc/ssl/porter_default.crt;
+        ssl_certificate_key /etc/ssl/porter_default.key;
+
+        default_type text/plain;
+
+        location / {
+            return 404 "Domain not set up in Porter";
+        }
+    }
+
     include /etc/nginx/conf.d/*.conf;
 }

--- a/tests/LiveTestCase.php
+++ b/tests/LiveTestCase.php
@@ -3,6 +3,7 @@
 namespace Tests;
 
 use App\Porter;
+use App\Support\Mechanics\Mechanic;
 use Illuminate\Support\Facades\Artisan;
 
 class LiveTestCase extends BaseTestCase
@@ -30,6 +31,11 @@ class LiveTestCase extends BaseTestCase
 
     protected function preparePorter()
     {
+        // Mock the mechanic, so we don't have to trust the CA Cert
+        $mechanic = \Mockery::mock(Mechanic::class);
+        $mechanic->shouldReceive('trustCA')->once();
+        $this->app->instance(Mechanic::class, $mechanic);
+
         $this->porter = $this->app[Porter::class];
 
         Artisan::call('begin', ['home' => __DIR__.'/TestWebRoot', '--force' => true]);

--- a/tests/Unit/Commands/BeginTest.php
+++ b/tests/Unit/Commands/BeginTest.php
@@ -28,7 +28,7 @@ class BeginTest extends BaseTestCase
     /** @test */
     public function it_uses_the_supplied_home_directory()
     {
-       $this->mockMechanic();
+        $this->mockMechanic();
 
         $home = storage_path('temp/test_home');
         file_exists($home) ? null : mkdir($home, 0777, true);

--- a/tests/Unit/Commands/BeginTest.php
+++ b/tests/Unit/Commands/BeginTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Unit\Commands;
 
 use App\Support\Images\Organiser\Organiser;
+use App\Support\Mechanics\Mechanic;
 use Illuminate\Support\Facades\Artisan;
 use Tests\BaseTestCase;
 
@@ -27,6 +28,8 @@ class BeginTest extends BaseTestCase
     /** @test */
     public function it_uses_the_supplied_home_directory()
     {
+       $this->mockMechanic();
+
         $home = storage_path('temp/test_home');
         file_exists($home) ? null : mkdir($home, 0777, true);
 
@@ -39,9 +42,19 @@ class BeginTest extends BaseTestCase
     /** @test */
     public function it_uses_the_current_directory_if_no_interaction()
     {
+        $this->mockMechanic();
+
         $this->artisan('begin', ['--force' => true, '--no-interaction' => true]);
 
         $expected = 'Setting home to '.base_path();
         $this->stringContains($expected)->evaluate(Artisan::output());
+    }
+
+    protected function mockMechanic()
+    {
+        $mechanic = \Mockery::mock(Mechanic::class);
+        $mechanic->shouldReceive('trustCA')->once();
+
+        $this->app->instance(Mechanic::class, $mechanic);
     }
 }

--- a/tests/Unit/Commands/MakeFilesTest.php
+++ b/tests/Unit/Commands/MakeFilesTest.php
@@ -7,6 +7,7 @@ use App\Commands\DockerCompose\Stop;
 use App\Models\Site;
 use App\Porter;
 use App\Support\Nginx\SiteConfBuilder;
+use App\Support\Ssl\CertificateBuilder;
 use Mockery\MockInterface;
 use Tests\BaseTestCase;
 use Tests\Unit\Support\Concerns\MocksPorter;
@@ -22,6 +23,7 @@ class MakeFilesTest extends BaseTestCase
     public function it_will_remake_the_files()
     {
         $conf = $this->mockSiteConfigBuilder();
+        $cert = $this->mockCertificateBuilder();
 
         factory(Site::class, 2)->create([]);
 
@@ -29,6 +31,7 @@ class MakeFilesTest extends BaseTestCase
         $this->porter->shouldReceive('compose');
 
         $conf->shouldReceive('build')->twice();
+        $cert->shouldReceive('build')->with('porter_default')->once();
 
         $this->artisan('make-files');
     }
@@ -40,6 +43,7 @@ class MakeFilesTest extends BaseTestCase
         $this->mockPorterCommand(Stop::class);
 
         $conf = $this->mockSiteConfigBuilder();
+        $cert = $this->mockCertificateBuilder();
 
         factory(Site::class, 2)->create([]);
 
@@ -47,6 +51,7 @@ class MakeFilesTest extends BaseTestCase
         $this->porter->shouldReceive('compose');
 
         $conf->shouldReceive('build')->twice();
+        $cert->shouldReceive('build')->with('porter_default')->once();
 
         $this->artisan('make-files');
     }
@@ -63,5 +68,19 @@ class MakeFilesTest extends BaseTestCase
         $this->app->instance(SiteConfBuilder::class, $conf);
 
         return $conf;
+    }
+
+    /**
+     * Mock the CertificateBuilder.
+     *
+     * @return MockInterface
+     */
+    protected function mockCertificateBuilder()
+    {
+        $builder = \Mockery::mock(CertificateBuilder::class);
+
+        $this->app->instance(CertificateBuilder::class, $builder);
+
+        return $builder;
     }
 }

--- a/tests/Unit/Commands/Sites/RenewCertificatesTest.php
+++ b/tests/Unit/Commands/Sites/RenewCertificatesTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Tests\Unit\Commands\Sites;
+
+use App\Models\Site;
+use App\Support\Ssl\CertificateBuilder;
+use Mockery\MockInterface;
+use Tests\BaseTestCase;
+
+class RenewCertificatesTest extends BaseTestCase
+{
+    /** @test */
+    public function it_renews_the_certificates()
+    {
+        factory(Site::class)->create(['secure' => true]);
+
+        $builder = $this->mockCertificateBuilder();
+        $builder->shouldReceive('clearCertificates')->with(false)->once();
+        $builder->shouldReceive('build')->with('porter_default')->once();
+
+        foreach (Site::all() as $site) {
+            $builder->shouldReceive('build')->with($site->url)->once();
+        }
+
+        $this->app->instance(CertificateBuilder::class, $builder);
+
+        $this->artisan('site:renew-certs');
+    }
+
+    /** @test */
+    public function it_will_clear_ca_certs()
+    {
+        $builder = $this->mockCertificateBuilder();
+        $builder->shouldReceive('clearCertificates')->with(true)->once();
+        $builder->shouldReceive('build')->zeroOrMoreTimes();
+
+        $this->app->instance(CertificateBuilder::class, $builder);
+
+        $this->artisan('site:renew-certs', ['--clear-ca' => true]);
+    }
+
+    /**
+     * Mock the CertificateBuilder.
+     *
+     * @return MockInterface
+     */
+    protected function mockCertificateBuilder()
+    {
+        $builder = \Mockery::mock(CertificateBuilder::class);
+
+        $this->app->instance(CertificateBuilder::class, $builder);
+
+        return $builder;
+    }
+}


### PR DESCRIPTION
- There is an addition to the nginx.conf file, which you will
  need to replace or adjust if already using Porter. See:
  resources/stubs/config/nginx/nginx.conf and edit
  ~/.porter/conf/nginx/nginx.conf

- This adds two default server blocks which show a message when
  trying to access a site that has not been set up on Porter.

- It also adds a new porter_default SSL certificate that is needed
  for serving the https default server. This is generated during
  the 'make-files' command (and therefore during 'begin'), and also
  'site:renew-certs'.

- Updated readme

- To solve issue #48 